### PR TITLE
Theme issue fixes and optimizations

### DIFF
--- a/PowerPlanSwitcher/PowerSchemeSelectorDlg.Designer.cs
+++ b/PowerPlanSwitcher/PowerSchemeSelectorDlg.Designer.cs
@@ -34,6 +34,7 @@ namespace PowerPlanSwitcher
             // 
             // TlpPowerSchemes
             // 
+            TlpPowerSchemes.BackColor = Color.LightGray;
             TlpPowerSchemes.ColumnCount = 1;
             TlpPowerSchemes.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
             TlpPowerSchemes.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
@@ -41,18 +42,20 @@ namespace PowerPlanSwitcher
             TlpPowerSchemes.Location = new Point(0, 0);
             TlpPowerSchemes.Margin = new Padding(0);
             TlpPowerSchemes.Name = "TlpPowerSchemes";
+            TlpPowerSchemes.Padding = new Padding(1);
             TlpPowerSchemes.RowCount = 1;
             TlpPowerSchemes.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
             TlpPowerSchemes.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
-            TlpPowerSchemes.Size = new Size(569, 344);
+            TlpPowerSchemes.Size = new Size(569, 390);
             TlpPowerSchemes.TabIndex = 0;
             // 
             // PowerSchemeSelectorDlg
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleDimensions = new SizeF(7F, 17F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.Black;
-            ClientSize = new Size(569, 344);
+            CausesValidation = false;
+            ClientSize = new Size(569, 390);
             Controls.Add(TlpPowerSchemes);
             FormBorderStyle = FormBorderStyle.None;
             Icon = (Icon)resources.GetObject("$this.Icon");

--- a/PowerPlanSwitcher/PowerSchemeSelectorDlg.cs
+++ b/PowerPlanSwitcher/PowerSchemeSelectorDlg.cs
@@ -18,6 +18,14 @@ namespace PowerPlanSwitcher
             IsLightMode()
             ? SystemColors.ControlText
             : SystemColors.HighlightText;
+        private static Color FBCColor =>
+            IsLightMode()
+            ? SystemColors.HighlightText
+            : SystemColors.MenuText;
+        private static Color FAMOBColor =>
+            IsLightMode()
+            ? Color.FromArgb(0xD8, 0xD8, 0xD8)
+            : Color.FromArgb(0x35, 0x35, 0x35);
 
         private const int ButtonHeight = 50;
         private const int ButtonWidth = 360;
@@ -35,7 +43,7 @@ namespace PowerPlanSwitcher
             name ??= guid.ToString();
             var button = new Button
             {
-                FlatStyle = FlatStyle.Popup,
+                FlatStyle = FlatStyle.Flat,
                 Image = icon,
                 ImageAlign = ContentAlignment.MiddleLeft,
                 TextImageRelation = TextImageRelation.ImageBeforeText,
@@ -51,7 +59,12 @@ namespace PowerPlanSwitcher
                 Tag = guid,
                 Dock = DockStyle.Fill,
             };
-
+            button.FlatAppearance.BorderSize = 0;
+            button.FlatAppearance.BorderColor =
+                    FBCColor;
+            button.FlatAppearance.MouseOverBackColor =
+                    FAMOBColor;
+                    
             button.Click += (_, _) =>
             {
                 PowerManager.SetActivePowerScheme((Guid)button.Tag);


### PR DESCRIPTION
Repair the black border of white theme buttons, optimize the visual segmentation by adding a gray border.

Before modification
![屏幕截图 2024-05-12 120632](https://github.com/SebastianBecker2/PowerPlanSwitcher/assets/106533733/d2e71213-6b16-45bf-8da1-33502548723b)


After modification
![屏幕截图 2024-05-12 162653](https://github.com/SebastianBecker2/PowerPlanSwitcher/assets/106533733/280075dd-2708-4eb3-9a20-f1843419783a)
