### PR TITLE
reformulation_discrete-Centered ToastDlg display

### DIFF
--- a/PowerPlanSwitcher/ToastDlg.cs
+++ b/PowerPlanSwitcher/ToastDlg.cs
@@ -62,29 +62,43 @@ namespace PowerPlanSwitcher
 
         private static Point GetPositionOnTaskbar(Size windowSize)
         {
-            var bounds = Taskbar.CurrentBounds;
-            switch (Taskbar.Position)
-            {
-                case TaskbarPosition.Left:
-                    bounds.Location += bounds.Size;
-                    return new Point(bounds.X, bounds.Y - windowSize.Height);
+        //1.
+            // var bounds = Taskbar.CurrentBounds;
+            // switch (Taskbar.Position)
+            // {
+                // case TaskbarPosition.Left:
+                    // bounds.Location += bounds.Size;
+                    // return new Point(bounds.X, bounds.Y - windowSize.Height);
 
-                case TaskbarPosition.Top:
-                    bounds.Location += bounds.Size;
-                    return new Point(bounds.X - windowSize.Width, bounds.Y);
+                // case TaskbarPosition.Top:
+                    // bounds.Location += bounds.Size;
+                    // return new Point(bounds.X - windowSize.Width, bounds.Y);
 
-                case TaskbarPosition.Right:
-                    bounds.Location -= windowSize;
-                    return new Point(bounds.X, bounds.Y + bounds.Height);
+                // case TaskbarPosition.Right:
+                    // bounds.Location -= windowSize;
+                    // return new Point(bounds.X, bounds.Y + bounds.Height);
 
-                case TaskbarPosition.Bottom:
-                    bounds.Location -= windowSize;
-                    return new Point(bounds.X + bounds.Width, bounds.Y);
+                // case TaskbarPosition.Bottom:
+                    // bounds.Location -= windowSize;
+                    // return new Point(bounds.X + bounds.Width, bounds.Y);
 
-                case TaskbarPosition.Unknown:
-                default:
-                    return new Point(0, 0);
-            }
+                // case TaskbarPosition.Unknown:
+                // default:
+                    // return new Point(0, 0);
+            // }
+        
+        //2. center the screen
+            // Rectangle workArea = Screen.PrimaryScreen.WorkingArea;
+            // int x = workArea.Left + (workArea.Width - windowSize.Width) / 2;
+            // int y = workArea.Top + (workArea.Height - windowSize.Height) / 2;
+            // return new Point(x, y);
+
+
+
+        //3. follow system
+            Rectangle workArea = Screen.PrimaryScreen.WorkingArea;
+            int y = workArea.Top + (workArea.Height - windowSize.Height) / 2;
+            return new Point(workArea.Left + (workArea.Width - windowSize.Width), y);
         }
 
         private void Any_Click(object sender, EventArgs e) => Dispose();


### PR DESCRIPTION
Centered ToastDlg display
"1." the original.
"2." is the main display screen centered, which is what I thought, because that's what my laptop driver animation looks like. 
"3." is the system "atl+shift" to switch between languages will pop up the system window, I made it consistent with the system
![屏幕截图 2024-06-27 110738](https://github.com/SebastianBecker2/PowerPlanSwitcher/assets/106533733/56b586d3-bec7-4bb9-a69d-ab74e7c9d3a2)
![屏幕截图 2024-06-27 110537](https://github.com/SebastianBecker2/PowerPlanSwitcher/assets/106533733/01cd7c66-6fd1-4c43-beee-b9ef2bfe595c)
![屏幕截图 2024-06-27 110649](https://github.com/SebastianBecker2/PowerPlanSwitcher/assets/106533733/43e8c538-e1a3-49b1-a5ce-deefe14a330c)