### PR TITLE
reformulation_discrete-battery monito_SettingsDlg

### DIFF
--- a/PowerPlanSwitcher/SettingsDlg.cs
+++ b/PowerPlanSwitcher/SettingsDlg.cs
@@ -72,7 +72,7 @@ namespace PowerPlanSwitcher
                 .Select(scheme => scheme.name)
                 .Cast<object>()
                 .ToArray());
-            if (Settings.Default.InitialPowerSchemeGuid == Guid.Empty)
+            if (Settings.Default.AcPowerSchemeGuid == Guid.Empty)
             {
                 CmbAcPowerScheme.SelectedIndex = 0;
             }
@@ -80,22 +80,22 @@ namespace PowerPlanSwitcher
             {
                 CmbAcPowerScheme.SelectedIndex = powerSchemes.FindIndex(
                     scheme => scheme.guid
-                        == Settings.Default.InitialPowerSchemeGuid);
+                        == Settings.Default.AcPowerSchemeGuid);
             }
 
             CmbBatteryPowerScheme.Items.AddRange(powerSchemes
                 .Select(scheme => scheme.name)
                 .Cast<object>()
                 .ToArray());
-            if (Settings.Default.InitialPowerSchemeGuid == Guid.Empty)
+            if (Settings.Default.BatterPowerSchemeGuid == Guid.Empty)
             {
-                CmbAcPowerScheme.SelectedIndex = 0;
+                CmbBatteryPowerScheme.SelectedIndex = 0;
             }
             else
             {
-                CmbAcPowerScheme.SelectedIndex = powerSchemes.FindIndex(
+                CmbBatteryPowerScheme.SelectedIndex = powerSchemes.FindIndex(
                     scheme => scheme.guid
-                        == Settings.Default.InitialPowerSchemeGuid);
+                        == Settings.Default.BatterPowerSchemeGuid);
             }
 
             ChbShowToastNotifications.Checked =


### PR DESCRIPTION
There is an bug in lines 71 through 99 of "SettingsDlg.cs".(Fixed) But I don't know how the battery power detection and switching logic was refactored after the refactoring, but sure enough, there is something wrong with the battery detection and switching logic